### PR TITLE
Release the PC Paint font file when quitting.

### DIFF
--- a/src/rendering/directdraw.cpp
+++ b/src/rendering/directdraw.cpp
@@ -87,6 +87,9 @@ DirectDraw::~DirectDraw()
     SafeRelease(directDrawStuff->dd);
     
     DeleteObject(this->afont);
+    
+    if (options) SetCurrentDirectory(options->program_directory.c_str());
+    RemoveFontResource(L"PCPaintBoldSmall.ttf");
 }
 
 Filter* oldGbFilter;


### PR DESCRIPTION
hhugboy calls"AddFontResource(L"PCPaintBoldSmall.ttf")", but fails to call RemoveFontResource at the end.
This results in the operating system keeping the .ttf file in use even after the emulator has quit, making it impossible to delete the file until the next reboot.

Solution: Release the PC Paint font file when quitting.