### PR TITLE
Add Rocman X protection to Sachen MMC2 emulation via GBX mapper-specific variables

### DIFF
--- a/src/memory/CartDetection.cpp
+++ b/src/memory/CartDetection.cpp
@@ -32,6 +32,7 @@
 Cartridge* CartDetection::processRomInfo(byte* rom, int romFileSize)
 {
     Cartridge* cartridge = new Cartridge();
+    memset(cartridge->mbcConfig, 0, 32);
     readHeader(rom, cartridge, romFileSize);
 
     if (GbxParser::isGbx(rom, romFileSize)) {

--- a/src/memory/GbxParser.cpp
+++ b/src/memory/GbxParser.cpp
@@ -57,6 +57,7 @@ bool GbxParser::parseFooter(byte* cartROM, Cartridge *cartridge, int romFileSize
     cartridge->battery = (bool)footer[4];
     cartridge->rumble = (bool)footer[5];
     cartridge->RTC = (bool)footer[6];
+    memcpy(cartridge->mbcConfig, footer +16, 32);
 
     sprintf(msg,"Mapped to internal MBC type %d / ROM size %d / RAM size %d",cartridge->mbcType, cartridge->ROMsize, cartridge->RAMsize);
     debug_win(msg);

--- a/src/memory/mbc/MbcUnlSachenMMC2.cpp
+++ b/src/memory/mbc/MbcUnlSachenMMC2.cpp
@@ -84,9 +84,11 @@ void MbcUnlSachenMMC2::writeMemory(unsigned short address, register byte data) {
 			break;
 		default:break;
 	}
+	// OPT1 solder pad
+	byte opt1bank =(*gbCartridge)->mbcConfig[0] &4? 0x10: 0x00;
 	// Update memory map
-	for (int bank =0; bank<=3; bank++) gbMemMap[bank] =&(*gbCartRom)[((outerBank &outerMask |                    0) <<14 &rom_size_mask[(*gbCartridge)->ROMsize]) +bank*0x1000];
-	for (int bank =4; bank<=7; bank++) gbMemMap[bank] =&(*gbCartRom)[((outerBank &outerMask | rom_bank &~outerMask) <<14 &rom_size_mask[(*gbCartridge)->ROMsize]) +bank*0x1000 -0x4000];
+	for (int bank =0; bank<=3; bank++) gbMemMap[bank] =&(*gbCartRom)[((outerBank &outerMask |                    0 | opt1bank) <<14 &rom_size_mask[(*gbCartridge)->ROMsize]) +bank*0x1000];
+	for (int bank =4; bank<=7; bank++) gbMemMap[bank] =&(*gbCartRom)[((outerBank &outerMask | rom_bank &~outerMask | opt1bank) <<14 &rom_size_mask[(*gbCartridge)->ROMsize]) +bank*0x1000 -0x4000];
 }
 
 void MbcUnlSachenMMC2::signalMemoryWrite(unsigned short address, register byte data) {

--- a/src/memory/mbc/MbcUnlSachenMMC2.cpp
+++ b/src/memory/mbc/MbcUnlSachenMMC2.cpp
@@ -61,8 +61,13 @@ byte MbcUnlSachenMMC2::readMemory(unsigned short address) {
 				address <<3 &0x10 |
 				address <<6 &0x40
 			;
+		// Depending on solder pad settings, 512 KiB and 1 MiB outer banks will return open bus.
+		if ((*gbCartridge)->mbcConfig[0] &1 && outerBank &outerMask &0x40 ||
+		(*gbCartridge)->mbcConfig[0] &2 && outerBank &outerMask &0x20)
+			return 0xFF;
 	}
 	// No Sachen MMC2 game seems to have a logo check, so no need to put the logo into video memory when not emulating the bootstrap ROM.
+	
 	return BasicMbc::readMemory(address);
 }
 

--- a/src/rom.h
+++ b/src/rom.h
@@ -59,6 +59,7 @@ struct Cartridge
    bool battery;
    bool RTC;
    bool rumble;
+   byte mbcConfig[32];
 };
 
 #endif


### PR DESCRIPTION
This required actually adding a field for the GBX mapper-specific variables to the Cartridge structure.