### PR TITLE
Support new Sachen dump 1B-005 (2002 Gedou Zhanlue)

### DIFF
--- a/src/GB.cpp
+++ b/src/GB.cpp
@@ -470,17 +470,17 @@ void gb_system::reset(bool change_mode, bool preserveMulticartState)
 
 void gb_system::cpu_reset()
 {   
-   A = 0x01;
-   F = 0xB0;
+   A = gbc_mode? 0x11: 0x01;
+   F = gbc_mode? 0x80: 0xB0;
    ZFLAG = HFLAG = CFLAG = 1;
    NFLAG = 0;
 //   flags = 0x5100;
       
-   BC.W = 0x0013;
-   DE.W = 0x00D8;
-   HL.W = 0x014D;
+   BC.W = gbc_mode? 0x0000: 0x0013;
+   DE.W = gbc_mode? 0xFF56: 0x00D8;
+   HL.W = gbc_mode? 0x000D: 0x014D;
    SP.W = 0xFFFE;
-   PC.W = haveBootstrap && options->use_bootstrap? 0x0000: 0x100;
+   PC.W = haveBootstrap && options->use_bootstrap? 0x0000: 0x0100;
    
    CPUHalt = 0;
    IME = 0;

--- a/src/memory/mbc/MbcUnlSachenMMC1.cpp
+++ b/src/memory/mbc/MbcUnlSachenMMC1.cpp
@@ -99,9 +99,10 @@ void MbcUnlSachenMMC1::writeMemory(unsigned short address, register byte data) {
 		case 2:	// ROM bank mask register
 			if ((rom_bank &0x30) ==0x30) outerMask =data;
 			break;
-		case 3:	break;
-		default:// Write to RAM, if present
+		case 5: // Write to RAM, if present
 			gbMemMap[address>>12][address&0x0FFF] = data;
+			return; // No memory map update needed
+		default:// other, ignore
 			return; // No memory map update needed
 	}
 	// Update memory map

--- a/src/memory/mbc/MbcUnlSachenMMC2.cpp
+++ b/src/memory/mbc/MbcUnlSachenMMC2.cpp
@@ -82,7 +82,11 @@ void MbcUnlSachenMMC2::writeMemory(unsigned short address, register byte data) {
 		case 2:	// ROM bank mask register
 			if ((rom_bank &0x30) ==0x30) outerMask =data;
 			break;
-		default:break;
+		case 5: // Write to RAM, if present
+			gbMemMap[address>>12][address&0x0FFF] = data;
+			return; // No memory map update needed
+		default:// other, ignore
+			return; // No memory map update needed
 	}
 	// OPT1 solder pad
 	byte opt1bank =(*gbCartridge)->mbcConfig[0] &4? 0x10: 0x00;

--- a/src/memory/mbc/MbcUnlSachenMMC2.cpp
+++ b/src/memory/mbc/MbcUnlSachenMMC2.cpp
@@ -20,6 +20,7 @@ void MbcUnlSachenMMC2::resetVars(bool preserveMulticartState) {
     rom_bank =1;
     mode =haveBootstrap && options->use_bootstrap? MODE_LOCKED_DMG: MODE_UNLOCKED;
     unlockCount =0;
+    sync();
 }
 
 void MbcUnlSachenMMC2::readMbcSpecificVarsFromStateFile(FILE *statefile) {
@@ -88,11 +89,7 @@ void MbcUnlSachenMMC2::writeMemory(unsigned short address, register byte data) {
 		default:// other, ignore
 			return; // No memory map update needed
 	}
-	// OPT1 solder pad
-	byte opt1bank =(*gbCartridge)->mbcConfig[0] &4? 0x10: 0x00;
-	// Update memory map
-	for (int bank =0; bank<=3; bank++) gbMemMap[bank] =&(*gbCartRom)[((outerBank &outerMask |                    0 | opt1bank) <<14 &rom_size_mask[(*gbCartridge)->ROMsize]) +bank*0x1000];
-	for (int bank =4; bank<=7; bank++) gbMemMap[bank] =&(*gbCartRom)[((outerBank &outerMask | rom_bank &~outerMask | opt1bank) <<14 &rom_size_mask[(*gbCartridge)->ROMsize]) +bank*0x1000 -0x4000];
+	sync();
 }
 
 void MbcUnlSachenMMC2::signalMemoryWrite(unsigned short address, register byte data) {
@@ -100,4 +97,12 @@ void MbcUnlSachenMMC2::signalMemoryWrite(unsigned short address, register byte d
 		unlockCount =0;
 		mode =MODE_LOCKED_CGB;
 	}
+}
+
+void MbcUnlSachenMMC2::sync() {
+	// OPT1 solder pad
+	byte opt1bank =(*gbCartridge)->mbcConfig[0] &4? 0x10: 0x00;
+	// Update memory map
+	for (int bank =0; bank<=3; bank++) gbMemMap[bank] =&(*gbCartRom)[((outerBank &outerMask |                    0 | opt1bank) <<14 &rom_size_mask[(*gbCartridge)->ROMsize]) +bank*0x1000];
+	for (int bank =4; bank<=7; bank++) gbMemMap[bank] =&(*gbCartRom)[((outerBank &outerMask | rom_bank &~outerMask | opt1bank) <<14 &rom_size_mask[(*gbCartridge)->ROMsize]) +bank*0x1000 -0x4000];
 }

--- a/src/memory/mbc/MbcUnlSachenMMC2.h
+++ b/src/memory/mbc/MbcUnlSachenMMC2.h
@@ -20,6 +20,7 @@ public:
         virtual void resetVars(bool preserveMulticartState) override;
         virtual void readMbcSpecificVarsFromStateFile(FILE *statefile) override;
         virtual void writeMbcSpecificVarsToStateFile(FILE *statefile) override;
+	virtual void sync();
 private:
 	byte	outerBank;
 	byte	outerMask;


### PR DESCRIPTION
- Perform external RAM writes in Sachen MMC2
- Correctly query external RAM address in Sachen MMC1
- Make CGB use the correct startup register state when not using a bootstrap ROM