### PR TITLE
Fix MBC5 logo swap behaviour between rom loads

### DIFF
--- a/src/GB.h
+++ b/src/GB.h
@@ -372,6 +372,8 @@ private:
     int romFileSize;
     bool loadrom_zip(const wchar_t* filename);
     bool loadrom_file(const wchar_t* filename, int offset);
+    void set_system_type(bool rereadHeader);
+    void map_bootstrap();
 };
 
 extern gb_system *GB;

--- a/src/memory/GB_mem.cpp
+++ b/src/memory/GB_mem.cpp
@@ -82,12 +82,15 @@ void gb_system::writememory(unsigned short address,byte data)
     mbc->signalMemoryWrite(address,data);
 }
 
+void gb_system::map_bootstrap()
+{
+    bootstrap = gbc_mode ? bootstrapCGB: bootstrapDMG;
+    haveBootstrap = gbc_mode ? haveBootstrap_CGB: haveBootstrap_DMG;
+    mapBootstrap = haveBootstrap && options->use_bootstrap;
+}
+
 void gb_system::mem_reset(bool preserveMulticartState)
 {
-   bootstrap =gbc_mode? bootstrapCGB: bootstrapDMG;
-   haveBootstrap =gbc_mode? haveBootstrap_CGB: haveBootstrap_DMG;
-   mapBootstrap =haveBootstrap && options->use_bootstrap;
-   
    memset(memory+0x8000,0x00,0x1FFF);
    memset(memory+0xFE00,0x00,0xA0);
 

--- a/src/memory/mbc/MbcNin5_LogoSwitch.cpp
+++ b/src/memory/mbc/MbcNin5_LogoSwitch.cpp
@@ -14,11 +14,20 @@
 #define MODE_LOCKED_CGB 1
 #define MODE_UNLOCKED   2
 #define MODE_DONE       3
+
+MbcNin5_LogoSwitch::MbcNin5_LogoSwitch() {
+    initLogoState();
+}
+
+void MbcNin5_LogoSwitch::initLogoState() {
+    logoMode = haveBootstrap && options->use_bootstrap ? MODE_LOCKED_DMG : MODE_DONE;
+    logoCount = 0;
+}
+
 void MbcNin5_LogoSwitch::resetVars(bool preserveMulticartState) {
     MbcNin5::resetVars(preserveMulticartState);
     if (!preserveMulticartState) {
-	logoMode =haveBootstrap && options->use_bootstrap? MODE_LOCKED_DMG: MODE_DONE;
-	logoCount =0;
+        initLogoState();
     }	
 }
 

--- a/src/memory/mbc/MbcNin5_LogoSwitch.h
+++ b/src/memory/mbc/MbcNin5_LogoSwitch.h
@@ -16,6 +16,7 @@
 //-------------------------------------------------------------------------
 class MbcNin5_LogoSwitch : public MbcNin5 {
 public:
+    MbcNin5_LogoSwitch();
     virtual void resetVars(bool preserveMulticartState) override;
     virtual byte readMemory(register unsigned short address) override;
     virtual void signalMemoryWrite(unsigned short address, register byte data) override;
@@ -24,6 +25,7 @@ public:
 private:
     byte logoMode;
     byte logoCount;
+    void initLogoState();
 };
 
 #endif //HHUGBOY_MBCNIN5_LOGOSWITCH_H

--- a/src/rom.cpp
+++ b/src/rom.cpp
@@ -252,6 +252,9 @@ bool gb_system::load_rom(const wchar_t* filename,int offset)
     if ( !romloaded ) return false;
 
     cartridge = (new CartDetection())->processRomInfo(cartROM, romFileSize);
+    // we have to set the system type here because auto detection works from the loaded ROM
+    // meanwhile some MBC initialisation depends on the loaded bootstrap, and the bootstrap depends on the system type
+    set_system_type(false);
     mbc->setMemoryReadWrite(cartridge->mbcType);
 
     wchar_t temp2[ROM_FILENAME_SIZE];


### PR DESCRIPTION
this required setting the system type and bootstrap immediately after the rom is loaded